### PR TITLE
Add new pages/routes

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -12,9 +12,18 @@ const NavbarList = styled.ul`
   justify-content: space-between;
   align-items: center;
   padding: 12px;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 `;
 const NavbarItem = styled.li`
   margin: 0 20px;
+
+  @media (max-width: 768px) {
+    margin: 10px 0;
+  }
 `;
 const NavbarLink = styled(Link)`
   text-decoration: none;
@@ -36,6 +45,12 @@ function Navbar() {
         </NavbarItem>
         <NavbarItem>
           <NavbarLink to={`/movies`}>Movies</NavbarLink>
+        </NavbarItem>
+        <NavbarItem>
+          <NavbarLink to={`/popular`}>Popular</NavbarLink>
+        </NavbarItem>
+        <NavbarItem>
+          <NavbarLink to={`/trending`}>Trending</NavbarLink>
         </NavbarItem>
       </NavbarList>
     </NavbarContainer>

--- a/routes/PopularPage.jsx
+++ b/routes/PopularPage.jsx
@@ -1,0 +1,12 @@
+import Navbar from '../components/Navbar';
+
+function PopularPage() {
+  return (
+    <>
+      <Navbar />
+      <h1>Popular Page</h1>
+    </>
+  );
+}
+
+export default PopularPage;

--- a/routes/TrendingPage.jsx
+++ b/routes/TrendingPage.jsx
@@ -1,0 +1,12 @@
+import Navbar from '../components/Navbar';
+
+function TrendingPage() {
+  return (
+    <>
+      <Navbar />
+      <h1>Trending Page</h1>
+    </>
+  );
+}
+
+export default TrendingPage;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,8 @@ import './index.css';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import ErrorPage from '../routes/ErrorPage.jsx';
 import MoviesPage from '../routes/MoviesPage.jsx';
+import PopularPage from '../routes/PopularPage.jsx';
+import TrendingPage from '../routes/TrendingPage.jsx';
 
 const router = createBrowserRouter([
   {
@@ -15,6 +17,16 @@ const router = createBrowserRouter([
   {
     path: '/movies',
     element: <MoviesPage />,
+    errorElement: <ErrorPage />,
+  },
+  {
+    path: '/popular',
+    element: <PopularPage />,
+    errorElement: <ErrorPage />,
+  },
+  {
+    path: '/trending',
+    element: <TrendingPage />,
     errorElement: <ErrorPage />,
   },
 ]);


### PR DESCRIPTION
Fixes: #16 

### Solution 
This PR creates two new routes; `/popular` & `/trending` by setting up react-router inside the `main.jsx` file. The new routes have their pages; `PopularPage.jsx` & `TrendingPage.jsx`. 

- `PopularPage.jsx` - A page where Popular pages get rendered (popularity is based on the [TMDB API](https://developer.themoviedb.org/docs))
- `TrendingPage.jsx` - A page where trending movies are rendered 

This PR also updates the `Navbar` component by adding route links that will take us to the newly created pages; `/popular` & `/trending`. 

#### Extras 
- Updates the styled-components inside the `Navbar` component to make sure the component stays mobile responsive after the addition of route links; `Popular` & `Trending`. 